### PR TITLE
cloud-init.adoc: extref:{handbook}[…] and tidbits

### DIFF
--- a/2022q3/cloud-init.adoc
+++ b/2022q3/cloud-init.adoc
@@ -8,14 +8,14 @@ link:https://github.com/canonical/cloud-init/blob/main/WIP-ONGOING-REFACTORIZATI
 Contact: Mina Galić <me+FreeBSD@igalic.co>
 
 cloud-init is the standard way of provisioning servers in the cloud.
-Unfortunately, cloud-init’s support for operating systems other than Linux is rather poor and the lack of cloud-init support on FreeBSD is a hindrance to cloud providers who want to offer FreeBSD as a Tier 1 platform.
+Unfortunately, cloud-init support for operating systems other than Linux is rather poor, and the lack of cloud-init support on FreeBSD is a hindrance to cloud providers who want to offer FreeBSD as a Tier 1 platform.
 To remedy this, this project aims to bring FreeBSD cloud-init support on par with Linux support. Though the plan is to lift support across all BSDs.
 
-The project deliverables include completing an extraction of certain networking classes, implementing man:ifconfig[8] and man:login.conf[5] parsers, implementing IPv6 configuration, creating man:devd.conf[5] rules for Azure, and writing Handbook documentation about productionizing FreeBSD.
+The project deliverables include completing an extraction of certain networking classes, implementing man:ifconfig[8] and man:login.conf[5] parsers, implementing IPv6 configuration, creating man:devd.conf[5] rules for Azure, and extref:{handbook}[FreeBSD Handbook] documentation about productionizing FreeBSD.
 
-On the way there, any BSD related bugs found in modules and documentation will also be fixed.
+On the way there, any BSD-related bugs found in modules and documentation will also be fixed.
 
-People interested in helping with the project can help with testing new features and fixes through the package:net/cloud-init-devel[], which will be updated on a weekly basis.
+People interested in helping with the project can help with testing new features and fixes through package:net/cloud-init-devel[], which will be updated on a weekly basis.
 Further, people with access to, and experience with, OpenBSD and NetBSD are also highly welcome to help.
 
 Sponsor: The FreeBSD Foundation +

--- a/2022q3/cloud-init.adoc
+++ b/2022q3/cloud-init.adoc
@@ -9,7 +9,7 @@ Contact: Mina Galić <me+FreeBSD@igalic.co>
 
 cloud-init is the standard way of provisioning servers in the cloud.
 Unfortunately, cloud-init support for operating systems other than Linux is rather poor, and the lack of cloud-init support on FreeBSD is a hindrance to cloud providers who want to offer FreeBSD as a Tier 1 platform.
-To remedy this, this project aims to bring FreeBSD cloud-init support on par with Linux support. Though the plan is to lift support across all BSDs.
+To remedy the situation, this project aims to bring FreeBSD cloud-init support on par with Linux support. The broader plan is to lift support across all BSDs.
 
 The project deliverables include completing an extraction of certain networking classes, implementing man:ifconfig[8] and man:login.conf[5] parsers, implementing IPv6 configuration, creating man:devd.conf[5] rules for Azure, and extref:{handbook}[FreeBSD Handbook] documentation about productionizing FreeBSD.
 


### PR DESCRIPTION
Resolve <https://github.com/freebsd/freebsd-quarterly/pull/515#discussion_r990589735>

Avoid "this, this". 

Hyphenate "BSD-related". 

Grammar, from: 

> through the net/cloud-init-devel, which

– to: 

> through net/cloud-init-devel, which

Et cetera. 